### PR TITLE
fix/cd aarch64 unknown linux gnu

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -81,6 +81,12 @@ jobs:
       - name: Setup Rust Cache
         uses: Swatinem/rust-cache@v2
 
+      - name: Install Linker for ARM64 Linux GNU
+        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
       - name: Setup Cargo Binstall
         uses: cargo-bins/cargo-binstall@main
 


### PR DESCRIPTION
This pull request adds support for cross-compiling to the ARM64 Linux GNU target (`aarch64-unknown-linux-gnu`). The main changes involve configuring the appropriate linker and updating the CI workflow to install the necessary toolchain when building for this target.

**Cross-compilation support for ARM64 Linux:**

* Added a `[target.aarch64-unknown-linux-gnu]` section in `.cargo/config.toml` to specify `aarch64-linux-gnu-gcc` as the linker.
* Updated the GitHub Actions workflow in `.github/workflows/cd.yml` to install the `gcc-aarch64-linux-gnu` package when building for the ARM64 Linux target.