### PR TITLE
chore: more readme details

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,22 @@
   <h1>BookWorm</h1>
   <small>Utilities to manage your ebook collection (PDFs, ePubs, KePubs, and more)</small>
 </div>
+
+## Installation
+
+### Cargo
+
+You can install BookWorm using Cargo. Run the following command in your terminal:
+
+```bash
+cargo install bookworm
+```
+
+### GitHub Releases
+
+You can also download precompiled binaries from the [GitHub Releases](https://githeub.com/LeoBorai/kepub/releases) page.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE.md) file for details.
+This project is also licensed under the Apache License 2.0 - see the [LICENSE-APACHE](LICENSE-APACHE.md) file for details.


### PR DESCRIPTION
This pull request adds an installation section to the `README.md` to help users easily install BookWorm. It also clarifies the project's dual licensing.

Documentation improvements:

* Added a new "Installation" section with instructions for installing BookWorm using Cargo and downloading binaries from GitHub Releases.
* Clarified licensing by specifying both MIT and Apache 2.0 licenses and pointing to the relevant files.