### PR TITLE
chore: use absolute link on readme image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <figure>
-      <img src="./docs/bookworm.png" height="80px" width="auto" />
+      <img src="https://raw.githubusercontent.com/LeoBorai/bookworm/refs/heads/main/docs/bookworm.png" height="80px" width="auto" />
   </figure>
   <h1>BookWorm</h1>
   <small>Utilities to manage your ebook collection (PDFs, ePubs, KePubs, and more)</small>


### PR DESCRIPTION
This pull request updates the image source in the `README.md` file to use an absolute URL rather than a relative path. This ensures the image renders correctly regardless of where the README is viewed. 

<!-- Updated the image source in `README.md` to use an absolute URL pointing to the project's main branch on GitHub, improving image reliability and visibility.<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
