### PR TITLE
fix: add missing fields for crate

### DIFF
--- a/src/bookworm/Cargo.toml
+++ b/src/bookworm/Cargo.toml
@@ -1,10 +1,15 @@
 [package]
 name = "bookworm"
-edition.workspace = true
-version.workspace = true
 authors.workspace = true
+version.workspace = true
+edition.workspace = true
+categories.workspace = true
 description.workspace = true
 documentation.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
 
 [[bin]]
 name = "bookworm"


### PR DESCRIPTION
This pull request updates the workspace-related metadata fields in the `src/bookworm/Cargo.toml` file to improve consistency and maintainability. Several fields that were previously missing are now included, ensuring that all relevant package information is inherited from the workspace configuration.

Workspace metadata improvements:

* Added `categories`, `keywords`, `license`, `repository`, and `readme` fields to inherit values from the workspace configuration.
* Reordered existing workspace fields for consistency and clarity.